### PR TITLE
Add working instructions to use this tutorial directly.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,9 @@
 [submodule "overdrive/etc/shellfire/paths.d"]
 	path = overdrive/etc/shellfire/paths.d
 	url = https://github.com/shellfire-dev/paths.d.git
+[submodule "overdrive/lib/shellfire/core"]
+	path = overdrive/lib/shellfire/core
+	url = https://github.com/shellfire-dev/core.git
 [submodule "overdrive/lib/shellfire/jsonreader"]
 	path = overdrive/lib/shellfire/jsonreader
 	url = https://github.com/shellfire-dev/jsonreader.git

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # A 10 min tutorial to create the [shellfire] application 'overdrive'
-If you'd rather not follow along, or if you'd prefer to see a complete application, take a look at the files in `overdrive`. (On a Mac with TextMate, `mate tutorial/overdrive`).
+If you'd rather not follow along, or if you'd prefer to see a complete application, take a look at the files in `overdrive`. (On a Mac with TextMate, `mate tutorial/overdrive`). To run the completed tutorial, clone this repository, then run in the project root:
+
+```bash
+git submodule update --init
+cd overdrive
+./overdrive gearbox.json
+cat gearbox.xml
+```
 
 'overdrive' is intended to be a simple application that converts 'GearBox' JSON files to XML. It shows how to quickly parse command lines, validate arguments and use the JSON and XML libraries.
 


### PR DESCRIPTION
Support a quickstart to see how shellfire works, both for pre-tutorial users (interested in shellfire behavior) and post-tutorial users (confirming that their project works like the one in the tutorial).
